### PR TITLE
Permit single character names

### DIFF
--- a/freecad/mnesarco/objects/named_objects.py
+++ b/freecad/mnesarco/objects/named_objects.py
@@ -31,7 +31,7 @@ Types = [
     ('Sketcher::SketchObject', tr('Sketch'), str(Icons.fc_create_sketch), 'SketcherWorkbench'),
 ]
 
-VALID_NAME = re.compile(r'[a-zA-Z]\w+')
+VALID_NAME = re.compile(r'[a-zA-Z]\w*')
 
 class NamedObjectForm(QtCore.QObject):
 


### PR DESCRIPTION
I wanted to name my spreadsheet "s", for max brevity, but the regex wanted at least two characters - not sure if that was intentional.  Either way I changed it.  Also, I see the same regex in scripts/dialogs.py and timers/dialogs.py, up to you if the change should be made there, too.  Thanks